### PR TITLE
sets the fortran standard to legacy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ set(DLOESS_C_SRC
   "src/misc.c"
 )
 
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -std=legacy")
+
 add_library(dloess STATIC ${DLOESS_C_SRC} ${DLOESS_FORTRAN_SRC})
 target_link_libraries(dloess INTERFACE m ${BLAS_LINKER_FLAGS} ${BLAS_LIBRARIES})
 set_property(TARGET dloess PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
The Fortran code contained in this repository is written using ancient FORTRAN77 which is rejected by modern Fortran compilers (such as gfortran V 11.1.0 ) as they default to using a more recent standard. To be able to build it successfully, the `-std=legacy` should be set. 

